### PR TITLE
feat: Added paywall validation hook

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -66,12 +66,7 @@ export default class ReactInstrumentationTealium {
   /* eslint-disable no-unused-vars */
   customEvent(payload, customEventCallback, customEventName = 'pageview') {
     return this.ensureScriptHasLoaded().then((resolve) => {
-      const newPayload = this.generatePayload(payload, customEventName);
-      if (newPayload) {
-        this.track(newPayload, customEventCallback);
-      } else {
-        resolve();
-      }
+      this.updateUtagData(this.generatePayload(payload, customEventName));
     }).catch((customEventError) => {
       /* eslint-disable no-console */
       console.error(customEventError.stack);
@@ -83,8 +78,6 @@ export default class ReactInstrumentationTealium {
     return this.customEvent(payload);
   }
 
-  // Some pages could be behind a paywall, we want send the data after the
-  // validation of the paywall.
   paywallvalidation(payload) {
     return this.customEvent(payload, () => true, 'paywallvalidation');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -27,6 +27,7 @@ export default class ReactInstrumentationTealium {
   get eventHandlers() {
     return {
       pageview: this.pageview.bind(this),
+      paywallvalidation: this.paywallvalidation.bind(this),
     };
   }
 
@@ -63,16 +64,30 @@ export default class ReactInstrumentationTealium {
   }
 
   /* eslint-disable no-unused-vars */
-  pageview(payload) {
-    return this.ensureScriptHasLoaded().then(() => (
-      this.updateUtagData(this.generatePayload(payload, 'pageview'))
-    )).catch((pageViewError) => {
+  customEvent(payload, customEventCallback, customEventName = 'pageview') {
+    return this.ensureScriptHasLoaded().then((resolve) => {
+      const newPayload = this.generatePayload(payload, customEventName);
+      if (newPayload) {
+        this.track(newPayload, customEventCallback);
+      } else {
+        resolve();
+      }
+    }).catch((customEventError) => {
       /* eslint-disable no-console */
-      console.error(pageViewError.stack);
+      console.error(customEventError.stack);
       /* eslint-enable no-console */
     });
   }
-  /* eslint-enable no-unused-vars */
+
+  pageview(payload) {
+    return this.customEvent(payload);
+  }
+
+  // Some pages could be behind a paywall, we want send the data after the
+  // validation of the paywall.
+  paywallvalidation(payload) {
+    return this.customEvent(payload, () => true, 'paywallvalidation');
+  }
 
   updateUtagData(additionalTrackingProps) {
     // Set initial value for utag_data.

--- a/test/index.js
+++ b/test/index.js
@@ -36,6 +36,26 @@ describe('TealiumPlugin is a i13n plugin for Tealium', () => {
       });
     });
   });
+  describe('pageview', () => {
+    it('calls customEvent', () => {
+      const plugin = new ReactI13nTealium(TealiumConfig);
+      plugin.customEvent = chai.spy();
+      plugin.pageview({
+        example: 'test',
+      });
+      plugin.customEvent.should.have.been.called.exactly(1);
+    });
+  });
+  describe('paywallvalidation', () => {
+    it('calls customEvent', () => {
+      const plugin = new ReactI13nTealium(TealiumConfig);
+      plugin.customEvent = chai.spy();
+      plugin.paywallvalidation({
+        example: 'test',
+      });
+      plugin.customEvent.should.have.been.called.exactly(1);
+    });
+  });
   describe('tealium plugin', () => {
     it('it calls utag.view() method with utag_data', () => {
       const TrackedApp = new ReactI13nTealium(TealiumConfig);

--- a/test/index.js
+++ b/test/index.js
@@ -15,6 +15,27 @@ describe('TealiumPlugin is a i13n plugin for Tealium', () => {
       loadExternalScript.should.have.been.called(1);
     });
   });
+  describe('customEvent', () => {
+    it('it calls ensureScriptHasLoaded and updateUtagData', (done) => {
+      const plugin = new ReactI13nTealium(TealiumConfig);
+      plugin.ensureScriptHasLoaded = chai.spy(() => Promise.resolve());
+      const payload = {
+        example: 'test',
+      };
+      plugin.updateUtagData = chai.spy();
+      plugin.generatePayload = chai.spy();
+      plugin.customEvent(payload, () => true, 'paywallvalidation').then(() => {
+        plugin.ensureScriptHasLoaded.should.have.been.called.exactly(1);
+        plugin.updateUtagData.should.have.been.called.exactly(1);
+        plugin.generatePayload.should.have.been.called.exactly(1);
+        plugin.generatePayload.should.have.been.called.with(payload, 'paywallvalidation');
+        done();
+      })
+      .catch((error) => {
+        done(error);
+      });
+    });
+  });
   describe('tealium plugin', () => {
     it('it calls utag.view() method with utag_data', () => {
       const TrackedApp = new ReactI13nTealium(TealiumConfig);


### PR DESCRIPTION
These changes bring this plugin in line with the omniture equivalent added at https://github.com/economist-components/react-i13n-omniture/commit/ec831f2fd93728968d4e7aad234b786cdd4f0ce4.

This means that the paywallvalidation function will be fired appropriately for tealium